### PR TITLE
Add new version for marriage auto-completion

### DIFF
--- a/app/assets/javascripts/logic.js
+++ b/app/assets/javascripts/logic.js
@@ -2,7 +2,7 @@ const relationshipSetup = () => {
 	const relationship = document.getElementById('relationship');
 
 	// Adjective form of marital status, Probably need to account for typos, different variations
-	const maritalStatuses = ['married', 'single', 'divorced', 'widowed', 'civilpartnered', 'civilpartnership'];
+	const maritalStatuses = ['married', 'single', 'divorced', 'widowed', 'civilpartnership'];
 	// Same as above, although this is the noun form
 	const relationshipStatuses = ['wife', 'husband', 'civilpartner', 'exwife', 'exhusband', 'separated']; // again, take into account different variations of these words, do we leave it up to the agent to translate?
 	// Collates the above two lists into one for an easy search but I think this may not be necessary
@@ -33,24 +33,25 @@ const relationshipSetup = () => {
 	const matchStatus = (val) => { // tidy up cases
 		switch(val) {
 			case 'wife':
-				return 'married';
 			case 'husband':
+			case 'married':
 				return 'married';
 
 			case 'civilpartner':
-				return 'civil parternship';
 			case 'civilpartnered':
-				return 'civil parternship';
 			case 'civilpartnership':
 				return 'civil parternship';
 
 			case 'exwife':
-				return 'divorced';
 			case 'exhusband':
+			case 'divorced':
 				return 'divorced';
 
 			case 'separated':
 				return 'separated';
+
+			case 'single':
+				return 'single';
 
 			default:
 				return ''

--- a/app/assets/javascripts/logic.js
+++ b/app/assets/javascripts/logic.js
@@ -4,8 +4,8 @@ const relationshipSetup = () => {
 	// Adjective form of marital status, Probably need to account for typos, different variations
 	const maritalStatuses = ['married', 'single', 'divorced', 'widowed', 'civilpartnership'];
 	// Same as above, although this is the noun form
-	const relationshipStatuses = ['wife', 'husband', 'civilpartner', 'exwife', 'exhusband', 'separated']; // again, take into account different variations of these words, do we leave it up to the agent to translate?
-	// Collates the above two lists into one for an easy search but I think this may not be necessary
+	// again, take into account different variations of these words, do we leave it up to the agent to translate?
+	const relationshipStatuses = ['wife', 'husband', 'civilpartner', 'exwife', 'exhusband', 'separated'];
 	const allStatuses = [...maritalStatuses, ...relationshipStatuses]
 
 	/*
@@ -15,7 +15,7 @@ const relationshipSetup = () => {
 	 */
 	const getRelationship = (val) => {
 		const relationship = val.toLowerCase().replace(/-|\s/g, '');
-		// probably don't need this as the default of match returns an empty string anyway
+		// Check this to prevent a pointless status match
 		const hasStatus = allStatuses.includes(relationship);
 
 		if (hasStatus) {
@@ -30,7 +30,7 @@ const relationshipSetup = () => {
 	 * @returns {string} relationship status of the deceased
 	 * multiple cases are being shit...
 	 */
-	const matchStatus = (val) => { // tidy up cases
+	const matchStatus = (val) => {
 		switch(val) {
 			case 'wife':
 			case 'husband':

--- a/app/assets/javascripts/logic.js
+++ b/app/assets/javascripts/logic.js
@@ -1,0 +1,86 @@
+const relationshipSetup = () => {
+	const relationship = document.getElementById('relationship');
+
+	// Adjective form of marital status, Probably need to account for typos, different variations
+	const maritalStatuses = ['married', 'single', 'divorced', 'widowed', 'civilpartnered', 'civilpartnership'];
+	// Same as above, although this is the noun form
+	const relationshipStatuses = ['wife', 'husband', 'civilpartner', 'exwife', 'exhusband', 'separated']; // again, take into account different variations of these words, do we leave it up to the agent to translate?
+	// Collates the above two lists into one for an easy search but I think this may not be necessary
+	const allStatuses = [...maritalStatuses, ...relationshipStatuses]
+
+	/*
+	 * Returns the relationship status
+	 * @param {string} val - The value of the relationship input
+	 * @returns {string} relationship status of the deceased
+	 */
+	const getRelationship = (val) => {
+		const relationship = val.toLowerCase().replace(/-|\s/g, '');
+		// probably don't need this as the default of match returns an empty string anyway
+		const hasStatus = allStatuses.includes(relationship);
+
+		if (hasStatus) {
+			return matchStatus(relationship);
+		}
+		return '';
+	}
+
+	/*
+	 * Returns the relationship status
+	 * @param {string} val - The value of the relationship input
+	 * @returns {string} relationship status of the deceased
+	 * multiple cases are being shit...
+	 */
+	const matchStatus = (val) => { // tidy up cases
+		switch(val) {
+			case 'wife':
+				return 'married';
+			case 'husband':
+				return 'married';
+
+			case 'civilpartner':
+				return 'civil parternship';
+			case 'civilpartnered':
+				return 'civil parternship';
+			case 'civilpartnership':
+				return 'civil parternship';
+
+			case 'exwife':
+				return 'divorced';
+			case 'exhusband':
+				return 'divorced';
+
+			case 'separated':
+				return 'separated';
+
+			default:
+				return ''
+		}
+	}
+
+	// Check the relationship element is present on the page
+	if (relationship) {
+		// Add an event listener for the input losing focus
+		relationship.addEventListener('blur', e => {
+			const { value } = e.target;
+			const relationshipValue = getRelationship(value);
+			if (relationshipValue) {
+				// Either a relationship or marital status has been inputted
+				const maritalStatusEl = document.getElementById('marital-status');
+				const maritalStatusChoiceEl = document.getElementsByClassName('js-marital-status-choice')[0];
+				// Check the maritalStatus element exists on the page
+				if (maritalStatusEl) {
+					// Set the value to be the correct state and then show the el on the next page
+					// conform to HTML standards, i.e ID names
+					maritalStatusEl.value = relationshipValue;
+					maritalStatusEl.parentElement.classList.remove('js-hidden'); // this should use the official gov one
+
+					if (maritalStatusChoiceEl) {
+						maritalStatusChoiceEl.classList.add('js-hidden');
+					}
+				}
+			}
+		});
+	}
+}
+
+relationshipSetup();

--- a/app/views/includes/scripts.html
+++ b/app/views/includes/scripts.html
@@ -6,6 +6,7 @@
 <script src="/public/javascripts/govuk/show-hide-content.js"></script>
 <script src="/public/javascripts/tabs.js"></script>
 <script src="/public/javascripts/application.js"></script>
+<script src="/public/javascripts/logic.js"></script>
 
 {% if useAutoStoreData %}
   <script src="/public/javascripts/auto-store-data.js"></script>

--- a/app/views/protos/agent-facing-v6/1-start.html
+++ b/app/views/protos/agent-facing-v6/1-start.html
@@ -1,0 +1,409 @@
+{% extends "layout.html" %}
+
+{% set agent = true %}
+
+{% block page_title %}
+Tell us about a death
+{% endblock %}
+
+{% block content %}
+
+{% include "includes/blue-banner.html" %}
+
+<main id="content" role="main">
+
+    <br>
+
+    <nav class="nav-bar2">
+      <ul>
+        <li>
+          <a href="#" class="active">New notification</a>
+        </li>
+        <li>
+          <a href="3-find" class="">Find notification</a>
+        </li>
+      </ul>
+    </nav>
+
+    <div class="grid-row">
+      <div class="column-two-thirds">
+
+
+          <div class="form-group"></div>
+        <!-- start Tabs -->
+
+      <div class="tabs">
+          <div class="tabs-nav">
+            <ul class="tabs-list">
+              <li>
+                <a href="#tab-1">
+                  Caller
+                </a>
+              </li>
+              <li>
+                <a id="tabButton-2" href="#tab-2">
+                  Deceased trace
+                </a>
+              </li>
+              <li>
+                <a id="tabButton-3" href="#tab-3">
+                  Deceased’s personal details
+                </a>
+              </li>
+            </ul>
+          </div>
+
+          <div class="tabs-content">
+            <div class="tabs-panel" id="tab-1">
+              <div class="tabs-panel-inner">
+                <h2 class="js-hidden heading-medium">Caller</h2>
+                    <h2 class="heading-medium">Caller’s details</h2>
+                    <form method="post" autocomplete="off">
+                      <div class="form-group">
+                        <label class="form-label-bold" for="full-name-caller">Full name</label>
+                        <input class="form-control" id="full-name-caller" name="full-name-caller" type="text">
+                      </div>
+
+                      <div class="form-group">
+                          <label class="form-label-bold" for="phone-number">
+                            Phone number
+                          </label>
+                          <input class="form-control" id="phone-number" type="text" name="phone-number">
+                        </div>
+
+                      <div class="form-group">
+                          <label class="form-label-bold" for="leaflet code">Leaflet code</label>
+                          <span class="form-hint">This a 6 digit code &ndash; for example, ‘AB123C’.
+                            <br>It’s on the leaflet, at the bottom.
+                          </span>
+                          <input class="form-control form-control-1-4" id="leaflet-code" name="leaflet-code" type="text">
+                        </div>
+                        <div class="form-group">
+                          <label class="form-label-bold" for="relationship">Relationship to deceased</label>
+                          <input class="form-control" id="relationship" name="relationship" type="text">
+                        </div>
+
+                        <div class="form-group">
+                          <fieldset>
+                            <label class="form-label-bold" for="nok">Is the caller the surviving spouse?</label>
+
+                            <div class="multiple-choice" data-target="nok-yes-panel">
+                              <input id="nok-yes" type="radio" name="radio-contact-group-1" value="Yes">
+                              <label for="nok-yes">Yes</label>
+                            </div>
+
+                            <div class="panel panel-border-narrow js-hidden" id="nok-yes-panel">
+                                <label class="form-label" for="postcode">Postcode</label>
+                                <input class="form-control form-control-1-4" id="postcode" type="text" name="postcode">
+                                <a class="button-secondary" href="#" role="button">Find address</a>
+                                <label class="form-label" for="phone-number">National Insurance number</label>
+                                <input class="form-control" id="phone-number" type="text" name="phone-number">
+                              </div>
+
+                            <div class="multiple-choice" data-target="nok-no-panel">
+                              <input id="nok-no" type="radio" name="radio-contact-group-1" value="No">
+                              <label for="nok-no">No</label>
+                            </div>
+                            <div class="panel panel-border-narrow js-hidden" id="nok-no-panel">
+                              <label class="form-label-bold" for="first-name-2">Who is the surviving spouse?</label>
+                              <label class="form-label" for="full-name">Full name</label>
+                              <input class="form-control" id="full-name" type="text" name="full-name">
+                              <label class="form-label" for="postcode">Postcode</label>
+                              <input class="form-control form-control-1-4" id="postcode" type="text" name="postcode">
+                              <a class="button-secondary" href="#" role="button">Find address</a>
+                              <label class="form-label" for="phone-number">Phone number</label>
+                              <input class="form-control" id="phone-number" type="text" name="phone-number">
+                            </div>
+                          </fieldset>
+                        </div>
+
+                        <div class="form-group">
+                          <fieldset>
+                            <label class="form-label-bold" for="executor">Is the caller dealing with the estate?</label>
+
+                            <div class="multiple-choice" data-target="executor-yes-panel">
+                              <input id="executor-yes" type="radio" name="radio-contact-group-2" value="Yes">
+                              <label for="executor-yes">Yes</label>
+                            </div>
+
+                            <div class="panel panel-border-narrow js-hidden" id="executor-yes-panel">
+                              <label class="form-label" for="postcode">Postcode</label>
+                              <input class="form-control form-control-1-4" id="postcode" type="text" name="postcode">
+                              <a class="button-secondary" href="#" role="button">Find address</a>
+                              <label class="form-label" for="phone-number">Phone number</label>
+                              <input class="form-control" id="phone-number" type="text" name="phone-number">
+                            </div>
+
+                            <div class="multiple-choice" data-target="executor-no">
+                              <input id="executor" type="radio" name="radio-contact-group-2" value="No">
+                              <label for="executor">No</label>
+                            </div>
+
+                            <div class="panel panel-border-narrow js-hidden" id="executor-no">
+                                <label class="form-label-bold" for="executor">Executor’s details</label>
+                                <label class="form-label" for="full-name">Full name</label>
+                                <input class="form-control" id="full-name" type="text" name="full-name">
+                                <label class="form-label" for="postcode">Postcode</label>
+                                <input class="form-control form-control-1-4" id="postcode" type="text" name="postcode">
+                                <a class="button-secondary" href="#" role="button">Find address</a>
+                                <label class="form-label" for="phone-number">Phone number</label>
+                                <input class="form-control" id="phone-number" type="text" name="phone-number">
+                              </div>
+                          </fieldset>
+                        </div>
+
+                        <button id="continue-to-deceased" class="button">Continue</button>
+
+                       </div>
+                    </div>
+
+            <div class="tabs-panel" id="tab-2">
+              <div class="tabs-panel-inner">
+                <h2 class="js-hidden heading-medium">
+                    Deceased trace
+                </h2>
+                <h2 class="heading-medium">Deceased trace</h1>
+                  <form method="post" autocomplete="off">
+
+                    <div class="form-group">
+                      <label class="form-label-bold" for="ni-number">
+                        National Insurance number
+                        <!--  <span class="form-hint">It's on your National Insurance card, benefit letter, payslip or P60.
+                            <br>For example, ‘QQ 12 34 56 C’.
+                            </span> -->
+                      </label>
+                      <input class="form-control" id="ni-number" type="text" name="ni-number">
+                    </div>
+
+                    <div class="form-group">
+                      <label class="form-label-bold" for="first-name-2">Full name</label>
+                      <input class="form-control" id="first-name-2" name="first-name-2" type="text">
+                    </div>
+
+                    <div class="form-group">
+                        <fieldset>
+                          <legend>
+                            <span class="form-label-bold">Date of birth</h2>
+                          </legend>
+                          <div class="form-date">
+                            <div class="form-group form-group-day">
+                              <label class="form-label" for="dob-day">Day</label>
+                              <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="dob-hint">
+                            </div>
+                            <div class="form-group form-group-month">
+                              <label class="form-label" for="dob-month">Month</label>
+                              <input class="form-control" id="dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+                            </div>
+                            <div class="form-group form-group-year">
+                              <label class="form-label" for="dob-year">Year</label>
+                              <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+                            </div>
+                          </div>
+                        </fieldset>
+                      </div>
+
+                      <div class="form-group js-hidden">
+                        <label class="form-label-bold" for="marital-status">
+                          Marital Status
+                          <!-- <span class="form-hint">
+                            This has been auto-populated based on your previous answer.
+                          </span> -->
+                        </label>
+                        <input class="form-control" id="marital-status" name="marital-status" type="text">
+                      </div>
+
+                      <div class="form-group">
+                        <fieldset>
+                          <label class="form-label-bold" for="nok">Have you traced the deceased in Searchlight?</label>
+
+                          <div class="multiple-choice" data-target="trace-yes-panel">
+                            <input id="trace-yes" type="radio" name="radio-contact-group-5" value="Yes">
+                            <label for="trace-yes">Yes</label>
+                          </div>
+
+                          <div class="panel panel-border-narrow js-hidden" id="trace-yes-panel">
+                            <label class="form-label" for="phone-number">Further security questions</label>
+                                  <div class="multiple-choice">
+                                    <input id="security-1" name="" type="checkbox" value="security-1">
+                                    <label for="security-1">Deceased Person’s 1st Line of Address</label>
+                                  </div>
+
+                                  <div class="multiple-choice">
+                                    <input id="security-2" name="" type="checkbox" value="security-2">
+                                    <label for="security-2">Deceased Person’s Post Code</label>
+                                  </div>
+                                  <div class="multiple-choice">
+                                      <input id="security-3" name="" type="checkbox" value="security-3">
+                                      <label for="security-3">Deceased Person’s Telephone number (landline or mobile is acceptable if both are recorded on system</label>
+                                    </div>
+                                    <!-- js-marital-status-choice is present so we can hide-->
+                                    <div class="multiple-choice js-marital-status-choice">
+                                      <input id="security-4" name="" type="checkbox" value="security-4">
+                                      <label for="security-4">Deceased Person’s marital status</label>
+                                    </div>
+
+                          </div>
+
+                          <div class="multiple-choice" data-target="trace-no-panel">
+                            <input id="trace-no" type="radio" name="radio-contact-group-5" value="No">
+                            <label for="trace-no">No</label>
+                          </div>
+                          <div class="panel panel-border-narrow js-hidden" id="trace-no-panel">
+                            <label class="form-label-bold" for="first-name-2">Refer caller to Bereavement Support Team</label>
+                            <span class="form-hint">Call 01234 567 890<br>
+                              NB: DWP only &ndash; all OGDs will have to be contacted separately
+                            </span>
+                        </fieldset>
+                      </div>
+
+                      <button id="continue-to-other" class="button">Continue</button>
+
+                    </div>
+                   </div>
+
+                   <div class="tabs-panel" id="tab-3">
+                      <div class="tabs-panel-inner">
+                        <h2 class="js-hidden heading-medium">
+                            Deceased’s personal details
+                        </h2>
+                        <h2 class="heading-medium">Deceased’s personal details</h1>
+                          <form method="post" autocomplete="off">
+
+                            <div class="form-group">
+                                <fieldset>
+                                  <legend>
+                                    <span class="form-label-bold">Date of death</h2>
+                                  </legend>
+                                  <div class="form-date">
+                                    <div class="form-group form-group-day">
+                                      <label class="form-label" for="dob-day">Day</label>
+                                      <input class="form-control" id="dob-day" name="dob-day" type="number" pattern="[0-9]*" min="0" max="31" aria-describedby="dob-hint">
+                                    </div>
+                                    <div class="form-group form-group-month">
+                                      <label class="form-label" for="dob-month">Month</label>
+                                      <input class="form-control" id="dob-month" name="dob-month" type="number" pattern="[0-9]*" min="0" max="12">
+                                    </div>
+                                    <div class="form-group form-group-year">
+                                      <label class="form-label" for="dob-year">Year</label>
+                                      <input class="form-control" id="dob-year" name="dob-year" type="number" pattern="[0-9]*" min="0" max="2016">
+                                    </div>
+                                  </div>
+                                </fieldset>
+                              </div>
+
+                              <div class="form-group">
+                                <fieldset>
+                                  <label class="form-label-bold" for="nok">Did they die in hospital?</label>
+
+                                  <div class="multiple-choice" data-target="hospital-yes-panel">
+                                    <input id="hospital-yes" type="radio" name="radio-contact-group-5" value="Yes">
+                                    <label for="hospital-yes">Yes</label>
+                                  </div>
+
+                                  <div class="panel panel-border-narrow js-hidden" id="hospital-yes-panel">
+                                    <label class="form-label" for="phone-number">Which hospital?</label>
+                                    <input class="form-control" id="phone-number" type="text" name="phone-number">
+                                    <label class="form-label" for="phone-number">How long were they in hospital?</label>
+                                    <input class="form-control form-control-1-4" id="phone-number" type="text" name="phone-number">
+                                  </div>
+
+                                  <div class="multiple-choice" data-target="hospital-no-panel">
+                                    <input id="hospital-no" type="radio" name="radio-contact-group-5" value="No">
+                                    <label for="hospital-no">No</label>
+                                  </div>
+                                  <div class="panel panel-border-narrow js-hidden" id="nok-no-panel">
+                                    <label class="form-label-bold" for="first-name-2">Who is the surviving spouse?</label>
+                                    <label class="form-label" for="full-name">Full name</label>
+                                    <input class="form-control" id="full-name" type="text" name="full-name">
+                                    <label class="form-label" for="postcode">Postcode</label>
+                                    <input class="form-control form-control-1-4" id="postcode" type="text" name="postcode">
+                                    <a class="button-secondary" href="#" role="button">Find address</a>
+                                    <label class="form-label" for="phone-number">How many days were they in hospital?</label>
+                                    <input class="form-control form-control-1-4" id="phone-number" type="text" name="phone-number">
+                                  </div>
+                                </fieldset>
+                              </div>
+
+                              <div class="form-group">
+                                <fieldset>
+                                  <label class="form-label-bold" for="nok">Same address as caller?</label>
+
+                                  <div class="multiple-choice" data-target="same-address-yes-panel">
+                                    <input id="same-address-yes" type="radio" name="radio-contact-group-6" value="Yes">
+                                    <label for="same-address-yes">Yes</label>
+                                  </div>
+
+                                  <div class="multiple-choice" data-target="same-address-no-panel">
+                                    <input id="same-address-no" type="radio" name="radio-contact-group-6" value="No">
+                                    <label for="same-address-no">No</label>
+                                  </div>
+                                  <div class="panel panel-border-narrow js-hidden" id="same-address-no-panel">
+                                    <label class="form-label" for="postcode">Postcode</label>
+                                    <input class="form-control form-control-1-4" id="postcode" type="text" name="postcode">
+                                    <a class="button-secondary" href="#" role="button">Find address</a>
+                                  </div>
+                                </fieldset>
+                              </div>
+
+                              <h2 class="heading-medium">Other information</h2>
+
+                              <div class="form-group">
+                                <fieldset>
+                                  <label class="form-label-bold" for="dvla">Did the deceased have a driving licence?</label>
+
+                                  <div class="multiple-choice" data-target="dvla-yes-panel">
+                                    <input id="dvla-yes" type="radio" name="radio-contact-group-8" value="Yes">
+                                    <label for="dvla-yes">Yes</label>
+                                  </div>
+
+                                  <div class="panel panel-border-narrow js-hidden" id="dvla-yes-panel">
+                                    <label class="form-label" for="phone-number">Driving licence number</label>
+                                    <input class="form-control" id="phone-number" type="text" name="phone-number">
+                                  </div>
+
+                                  <div class="multiple-choice" data-target="dvla-no-panel">
+                                    <input id="dvla-no" type="radio" name="radio-contact-group-8" value="No">
+                                    <label for="dvla-no">No</label>
+                                  </div>
+                                </fieldset>
+                              </div>
+                              <div class="form-group">
+                                <fieldset>
+                                  <label class="form-label-bold" for="passport">Did the deceased have a passport?</label>
+
+                                  <div class="multiple-choice" data-target="passport-yes-panel">
+                                    <input id="passport-yes" type="radio" name="radio-contact-group-9" value="Yes">
+                                    <label for="passport-yes">Yes</label>
+                                  </div>
+
+                                  <div class="panel panel-border-narrow js-hidden" id="passport-yes-panel">
+                                    <label class="form-label" for="phone-number">Passport number</label>
+                                    <input class="form-control" id="phone-number" type="text" name="passport-number">
+                                  </div>
+
+                                  <div class="multiple-choice" data-target="passport-no-panel">
+                                    <input id="passport-no" type="radio" name="radio-contact-group-9" value="No">
+                                    <label for="passport-no">No</label>
+                                  </div>
+                                </fieldset>
+                              </div>
+
+                              <a class="button" href="2-check-answers" role="button">Check all information</a>
+
+                            </div>
+                           </div>
+
+                </form>
+              </div>
+            </div>
+          </div>
+        </div>
+
+  <!-- end Tabs -->
+
+      </div>
+    </div>
+
+</main>
+
+{% endblock %}

--- a/app/views/protos/agent-facing-v6/2-check-answers.html
+++ b/app/views/protos/agent-facing-v6/2-check-answers.html
@@ -1,0 +1,287 @@
+{% extends "layout.html" %}
+
+{% set agent = true %}
+
+{% block page_title %}
+Tell us about a death
+{% endblock %}
+
+{% block content %}
+
+
+<main id="content" role="main">
+
+  <br>
+
+  <nav class="nav-bar2">
+      <ul>
+        <li>
+          <a href="1-start" class="active">New notification</a>
+        </li>
+        <li>
+          <a href="3-find" class="">Existing notification</a>
+        </li>
+      </ul>
+    </nav>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h2 class="heading-medium">Check this information</h2>
+      <p>You've collected details about the death of David Wood.</p>
+      <h2 class="heading-medium">Caller’s details</h2>
+        <dl class="govuk-check-your-answers cya-questions-short">
+          <div>
+            <dt class="cya-question">Name
+              </dt>
+              <dd class="cya-answer">
+                Hannah Wood
+              </dd>
+              <dd class="cya-change">
+                <a href="1-start">
+                  Change<span class="visually-hidden"> name</span>
+                </a>
+              </dd>
+            </div>
+
+            <div>
+                <dt class="cya-question">
+                  Leaflet code
+                </dt>
+                <dd class="cya-answer">
+                    AB657C
+                </dd>
+                <dd class="cya-change">
+                  <a href="1-start">
+                    Change<span class="visually-hidden"> Leaflet code</span>
+                  </a>
+                </dd>
+              </div>
+
+                <div>
+                  <dt class="cya-question">
+                    Relationship to deceased
+                  </dt>
+                  <dd class="cya-answer">
+                    Wife
+                  </dd>
+                  <dd class="cya-change">
+                    <a href="1-start">
+                      Change<span class="visually-hidden"> Relationship to deceased</span>
+                    </a>
+                  </dd>
+                </div>
+
+                <div>
+                  <dt class="cya-question">
+                    Address
+                  </dt>
+                  <dd class="cya-answer">
+                    72 Guild Street<br />
+                    London<br />
+                    SE23 6FH
+                  </dd>
+                  <dd class="cya-change">
+                    <a href="1-start">
+                      Change<span class="visually-hidden"> Address</span>
+                    </a>
+                  </dd>
+
+                </div>
+
+                <div>
+                    <dt class="cya-question">
+                      Phone number
+                    </dt>
+                    <dd class="cya-answer">
+                      0207 555 189
+                    </dd>
+                    <dd class="cya-change">
+                      <a href="1-start">
+                        Change<span class="visually-hidden">Phone number</span>
+                      </a>
+                    </dd>
+
+                  </div>
+
+          </dl>
+
+          <h2 class="heading-medium">Deceased’s details </h2>
+          <dl class="govuk-check-your-answers cya-questions-short">
+              <div>
+                <dt class="cya-question">
+                  Name
+                </dt>
+                <dd class="cya-answer">
+                  David Wood
+                </dd>
+                <dd class="cya-change">
+                  <a href="1-start">
+                    Change<span class="visually-hidden"> name</span>
+                  </a>
+                </dd>
+              </div>
+
+              <div>
+                  <dt class="cya-question">
+                    Date of birth
+                  </dt>
+                  <dd class="cya-answer">
+                    5 January 1954
+                  </dd>
+                  <dd class="cya-change">
+                    <a href="1-start">
+                      Change<span class="visually-hidden"> date of birth</span>
+                    </a>
+                  </dd>
+                </div>
+
+              <div>
+                <dt class="cya-question">
+                  National Insurance number
+                </dt>
+                <dd class="cya-answer">
+                  QQ 75 62 35 C
+                </dd>
+                <dd class="cya-change">
+                  <a href="1-start">
+                    Change<span class="visually-hidden"> date of birth</span>
+                  </a>
+                </dd>
+              </div>
+
+              <div>
+                  <dt class="cya-question">
+                    Date of death
+                  </dt>
+                  <dd class="cya-answer">
+                    30 April 2018
+                  </dd>
+                  <dd class="cya-change">
+                    <a href="1-start">
+                      Change<span class="visually-hidden"> date of birth</span>
+                    </a>
+                  </dd>
+                </div>
+
+              <div>
+                <dt class="cya-question">
+                  Home address
+                </dt>
+                <dd class="cya-answer">
+                  72 Guild Street<br />
+                  London<br />
+                  SE23 6FH
+                </dd>
+                <dd class="cya-change">
+                  <a href="1-start">
+                    Change<span class="visually-hidden"> home address</span>
+                  </a>
+                </dd>
+              </div>
+
+              <div>
+                  <dt class="cya-question">
+                    Passport number
+                  </dt>
+                  <dd class="cya-answer">
+                      925665416
+                  </dd>
+                  <dd class="cya-change">
+                    <a href="1-start">
+                      Change<span class="visually-hidden"> Passport number</span>
+                    </a>
+                  </dd>
+                </div>
+            </dl>
+
+
+
+
+
+
+         <!--
+      <table>
+        <caption class="heading-medium">The following changes will be made:</caption>
+        <thead>
+          <tr>
+            <td class="heading-small">What will change</td>
+            <td class="heading-small">How it will change</td>
+          </tr>
+        </thead>
+          <tbody>
+          <tr>
+            <td>State Pension</td>
+            <td>Payments will be suspended pending cancellation</td>
+          </tr>
+          <tr>
+            <td>Pension Credit</td>
+            <td>Payments will be suspended pending cancellation</td>
+          </tr>
+          <tr>
+            <td>Carer's Allowance</td>
+            <td>The underlying entitlement will be suspended pending cancellation</td>
+          </tr>
+          <tr>
+            <td> Housing Benefit </td>
+              <td>When we receive official confirmation of death, this will be adjusted</td>
+          </tr>
+          <tr>
+            <td>Council Tax</td>
+            <td>When we receive official confirmation of death, this will be adjusted</td>
+          </tr>
+          <tr>
+            <td>Attendance Allowance</td>
+            <td>Payments will be suspended pending cancellation</td>
+          </tr>
+          <tr>
+            <td>Blue Badge</td>
+            <td>This will be suspended pending cancellation to prevent fraudulent use</td>
+          </tr>
+          <tr>
+            <td>Council housing</td>
+            <td>When we receive official confirmation of death, the council will contact the
+              person dealing with the affairs of Jane Smith to let them know how the tenancy will change</td>
+          </tr>
+        </tbody>
+      </table> -->
+
+      <table>
+        <thead>
+          <caption class="heading-medium">Other information</caption>
+        </thead>
+        <tbody>
+          <tr>
+            <th>Driving licence number</th>
+            <td><a href="1-start#tab-2">Add</a></td>
+          </tr>
+         <!-- <tr>
+              <th>Vehicle registration</th>
+              <td><a href="#">Add</a></td>
+            </tr>
+          <tr>
+            <th>Passport number</th>
+            <td><a href="#">Add</a></td>
+          </tr> -->
+        </tbody>
+      </table>
+
+      <div class="notice" style="margin-top:50px; margin-bottom:50px">
+        <i class="icon icon-important">
+          <span class="visually-hidden">Please note</span>
+        </i>
+        <strong class="bold-small">The information you have provided will be passed on to the organisations.
+          Do I have your consent?
+        </strong>
+      </div>
+
+      <form method="post" autocomplete="off">
+        <div class="form-group">
+            <a class="button" href="6-wrap.html" role="button">Confirm and save notification</a>
+        </div>
+      </form>
+    </div>
+  </div>
+
+</main>
+
+{% endblock %}

--- a/app/views/protos/agent-facing-v6/3-find.html
+++ b/app/views/protos/agent-facing-v6/3-find.html
@@ -1,0 +1,45 @@
+{% extends "layout.html" %}
+
+{% set agent = true %}
+
+{% block page_title %}
+Tell us about a death
+{% endblock %}
+
+{% block content %}
+
+
+<main id="content" role="main">
+
+  <br>
+  <nav class="nav-bar2">
+    <ul>
+      <li>
+        <a href="1-start" class="">New notification</a>
+      </li>
+      <li>
+        <a href="#" class="active">Find notification</a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-medium">Find notification</h1>
+
+
+      <form autocomplete="off">
+          <div class="form-group search-group ">
+            <label for="search-box" class="form-label">
+              <span>Enter the deceased’s National Insurance number</span>
+            </label>
+            <input type="search" name="findNino" class="form-control form-control-search" id="search-box" autocomplete="off" value="">
+            <a class="button-search" href="4-found" role="button"><span class="visually-hidden">Search</span></a>
+          </div>
+        </form>
+    </div>
+  </div>
+
+</main>
+
+{% endblock %}

--- a/app/views/protos/agent-facing-v6/4-found.html
+++ b/app/views/protos/agent-facing-v6/4-found.html
@@ -1,0 +1,59 @@
+{% extends "layout.html" %}
+
+{% set agent = true %}
+
+{% block page_title %}
+Tell us about a death
+{% endblock %}
+
+{% block content %}
+
+
+<main id="content" role="main">
+
+  <br>
+  <nav class="nav-bar2">
+    <ul>
+      <li>
+        <a href="1-start" class="">New notification</a>
+      </li>
+      <li>
+        <a href="#" class="active">Find notification</a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-medium">Find notification</h1>
+      <form autocomplete="off">
+          <div class="form-group search-group ">
+            <label for="search-box" class="form-label">
+              <span>Enter the deceased’s National Insurance number</span>
+            </label>
+            <input type="search" name="findNino" class="form-control form-control-search" id="search-box" autocomplete="off" value="">
+            <a class="button-search" href="4-found" role="button"><span class="visually-hidden">Search</span></a>
+          </div>
+        </form>
+        <h2 class="heading-medium">Results</h2>
+        <ul class="search-results">
+            
+            <li class="result">
+              <a href="5-formatted" class="result-link">
+                Jane Smith
+              </a>
+              <span class="result-meta">
+                Deceased
+              </span>
+              <span class="result-meta">
+                30 April 2018
+              </span>
+            </li>
+          
+        </ul>
+    </div>
+  </div>
+
+</main>
+
+{% endblock %}

--- a/app/views/protos/agent-facing-v6/5-formatted.html
+++ b/app/views/protos/agent-facing-v6/5-formatted.html
@@ -1,0 +1,96 @@
+{% extends "layout.html" %}
+
+{% set agent = true %}
+
+{% block page_title %}
+Tell us about a death
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+    <br>
+
+  <nav class="nav-bar2">
+      <ul>
+        <li>
+          <a href="1-start" class="">New notification</a>
+        </li>
+        <li>
+          <a href="3-find" class="active">Existing notification</a>
+        </li>
+      </ul>
+    </nav>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+        <h2 class="heading-medium">Deceased’s information</h2>
+        <p>You are reviewing details about the death of Jane Smith.</p>
+        
+        <table>
+            <caption class="heading-medium">Deceased’s details</caption>
+            <tbody>
+              <tr>
+                <td>Name</td>
+                <td>Jane Smith</td>
+              </tr>
+              <tr>
+                <td>Date of Death</td>
+                <td>30 April 2018</td>
+              </tr>
+              <tr>
+                <td>National Insurance number</td>
+                <td>QQ 12 34 56 C</td>
+              </tr>
+              <tr>
+                  <td>Date of birth</td>
+                  <td>5 January 1954</td> 
+                </tr>
+              <tr>
+                <td>Address</td>
+                <td>72 Guild Street<br />
+                  London<br />
+                  SE23 6FH</td>
+              </tr>
+              <tr>
+                  <td>Passport number</td>
+                  <td>925665416</td>
+                </tr>
+            </tbody>
+          </table>
+        
+        <table>
+            <caption class="heading-medium">Notifier’s details</caption>
+            <tbody>
+              <tr>
+                <td>Name</td>
+                <td>John Smith</td>
+              </tr>
+              <tr>
+                <td>Leaflet code</td>
+                <td>AB123C</td>
+              </tr>
+              <tr>
+                <td>Relationship to deceased</td>
+                <td>Husband</td>
+              </tr>
+              <tr>
+                <td>Address</td>
+                <td>72 Guild Street<br />
+                  London<br />
+                  SE23 6FH</td>
+              </tr>
+              <tr>
+                  <td>Phone number</td>
+                  <td>01234 567 890</td>
+                </tr>
+            </tbody>
+          </table>
+
+          
+    </div>
+   </div>
+</main>
+
+{% endblock %}

--- a/app/views/protos/agent-facing-v6/6-wrap.html
+++ b/app/views/protos/agent-facing-v6/6-wrap.html
@@ -1,0 +1,59 @@
+{% extends "layout.html" %}
+
+{% set agent = true %}
+
+{% block page_title %}
+Tell us about a death
+{% endblock %}
+
+{% block content %}
+
+<main id="content" role="main">
+
+    <br>
+
+  <nav class="nav-bar2">
+      <ul>
+        <li>
+          <a href="1-start" class="">New notification</a>
+        </li>
+        <li>
+          <a href="3-find" class="">Existing notification</a>
+        </li>
+      </ul>
+    </nav>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <div class="govuk-box-highlight">
+        <h1 class="heading-xlarge">Notification complete</h1>
+      </div>
+      <h2 class="heading-medium">What this means</h2>
+      <p>We have passed the information the caller provided to all relevant government and local authority departments. They will suspend any services and benefits
+        Jane Smith received.</p>
+      <p>For example, if they:</p>
+      <ul class="list list-bullet">
+  <li>had a State Pension, this will be suspended</li>
+  <li>got benefits, like Employment and Support Allowance, this will be suspended</li>
+  <li>used a Blue Badge, this will be suspended</li>
+</ul>
+      <p>The caller will get a letter confirming this notification within 7 working days.</p>
+      <h2 class="heading-medium">What happens next</h2>
+      <p>When the death is registered with a registrar, the death will be confirmed.</p>
+      <p>This confirmation will then be passed on to relevant government and local authority departments. They will cancel any services and benefits that
+          Jane Smith was entitled to.</p>
+      <p>The caller will get a letter confirming which services and benefits have been cancelled within the next 4 weeks.</p>
+      <h2 class="heading-medium">Getting financial support</h2>
+      <p>If the next of kin can get any financial support following this death, we'll write to you with details of how to apply.</p>
+      <h2 class="heading-medium">Getting emotional support</h2>
+      <p>Cruse Bereavement Care is a voluntary organisation that offers emotional help and support during a bereavement.</p>
+      <p>
+        <strong>Cruse Bereavement Care</strong>
+        <br>Telephone: 0808 808 1677
+        <br>Website: www.cruse.org.uk</p>
+      <p>
+    </div>
+   </div>
+</main>
+
+{% endblock %}

--- a/app/views/protos/agent-facing-v6/tuaad-demo.html
+++ b/app/views/protos/agent-facing-v6/tuaad-demo.html
@@ -1,0 +1,49 @@
+{% extends "layout.html" %}
+
+{% set agent = true %}
+
+{% block page_title %}
+Tell us about a death
+{% endblock %}
+
+{% block content %}
+
+
+<main id="content" role="main">
+
+  <br>
+  <nav class="nav-bar2">
+    <ul>
+      <li>
+        <a href="1-start" class="">New notification</a>
+      </li>
+      <li>
+        <a href="#" class="active">Find notification</a>
+      </li>
+    </ul>
+  </nav>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+        <h1 class="heading-xlarge">Tell Us About A Death</h1>
+
+        <video width="900" height="auto" controls>
+          <source src="http://1810creative.com/dwp/TUAAD.mp4" type="video/mp4">
+        </video>
+  
+        <h2 class="heading-medium" id="tell">Tell Us About A Death</h2>
+        <p class="text">A short role-play video showing how a call to an agent is handled in our latest prototype.</p>
+
+        <ul class="list">
+          <li>
+            <a href="/protos/agent-facing-v3/1-start">
+              View prototype
+            </a>
+          </li>
+        </ul>
+    </div>
+  </div>
+
+</main>
+
+{% endblock %}


### PR DESCRIPTION
Made a new version from the V5 prototype that extends current functionality to include auto-completion on the deceased person's `marital status`.

Entering any of the following,`'wife', 'husband', 'civil partner', 'ex wife', 'ex husband', 'separated'` (spaces and `-` are stripped out, so will also be compatible) in the caller's `relationship to deceased` will autopopulate the deceased person's `marital status` and will map it to the correct status, for example, married. 

Copied folder from V5, and made changes to
 - app/views/protos/agent-facing-v6/1-start.html
- app/assets/javascripts/logic.js
- app/views/includes/scripts.html

Some things need to adhere to govuk standards, i.e showing and hiding, guessing there's a lib out there somewhere, but not tracked it down just yet.